### PR TITLE
Fix Gadfly 1.3 compatibility

### DIFF
--- a/src/plottingfunctions.jl
+++ b/src/plottingfunctions.jl
@@ -170,7 +170,7 @@ function plot_gaslift(well::Wellbore, tubing_pressures, casing_pressures, temps,
                 Guide.ylabel("Measured Depth (ft)"),
                 Guide.title(ctitle),
                 Coord.cartesian(yflip = true),
-                Guide.manual_color_key(nothing,
+                Guide.manual_color_key("",
                                        ["TP", "CP", "Valves", "PVO/PVC"],
                                        ["deepskyblue", "mediumspringgreen", "black", "mediumpurple3"]),
                 Theme(plot_padding=[5mm, 0mm, 5mm, 5mm]))


### PR DESCRIPTION
`manual_color_key` no longer accepts `nothing` for key title in Gadfly 1.3